### PR TITLE
Mmg mesh refinement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies=[
         'OCP',
         'meshio',
         'trimesh',
+        'networkx',
         'Cython'
 ]
 

--- a/src/CAD_to_OpenMC/assemblymesher_cq.py
+++ b/src/CAD_to_OpenMC/assemblymesher_cq.py
@@ -127,8 +127,8 @@ class MesherCQSTL:
           volumefaces.append(facename)
           if (self.refine):
             self._refine_stls(facename)
-        #merge the stls to a single .stl
-        merge_stl(volname, volumefaces,of='bin')
+      #merge the stls to a single .stl
+      merge_stl(volname, volumefaces,of='bin')
       e.stl=volname
 
 class MesherCQSTLBuilder:

--- a/src/CAD_to_OpenMC/assemblymesher_cq.py
+++ b/src/CAD_to_OpenMC/assemblymesher_cq.py
@@ -3,6 +3,7 @@ import subprocess as sp
 import pathlib as pl
 import hashlib as hl
 from .stl_utils import *
+from . import meshutils
 
 class MesherCQSTL:
   def __init__(self, tolerance, angular_tolerance, default, refine, entities):
@@ -63,11 +64,12 @@ class MesherCQSTL:
       buf,n=read_stl(vf)
       verts=buffer2vertices(buf)
       triangles=buffer2triangles(buf,verts)
-      if (totalverts is None):
+      if (all_verts is None):
         all_verts=verts
         all_triangles=triangles
-        all_tlabels=(i+1)*np.ones((triangles.shape[0],1),dtype='uint')
-        all_vlabels=(i+1)*np.ones((verts.shape[0],1),dtype='uint')
+        all_tlabels=(i+1)*np.ones((triangles.shape[0]),dtype='uint')
+        all_vlabels=1*np.ones((verts.shape[0]),dtype='uint')
+        vertex_count=verts.shape[0]
       else:
         all_verts=np.vstack((all_verts,verts))
         all_triangles=np.vstack((all_triangles,triangles)

--- a/src/CAD_to_OpenMC/assemblymesher_cq.py
+++ b/src/CAD_to_OpenMC/assemblymesher_cq.py
@@ -130,11 +130,6 @@ class MesherCQSTL:
         #merge the stls to a single .stl
         merge_stl(volname, volumefaces,of='bin')
       e.stl=volname
-      #we have now a full stl-description of volume with completely imprinted surfaces
-          #surface is not in table - we need to mesh (and possibly remesh) it
-          #and put it into the main facetable as well as the local table for this volume.
-          #refine?
-          #if so reimport
 
 class MesherCQSTLBuilder:
   def __init__(self):

--- a/src/CAD_to_OpenMC/assemblymesher_cq.py
+++ b/src/CAD_to_OpenMC/assemblymesher_cq.py
@@ -12,6 +12,9 @@ class MesherCQSTL:
     self.entities=entities
     self.verbose=2
     self.refine=refine
+    self.default=default
+    self.min_mesh_size=min_mesh_size
+    self.max_mesh_size=max_mesh_size
 
   def generate_stls(self):
     self._mesh_surfaces()

--- a/src/CAD_to_OpenMC/assemblymesher_cq.py
+++ b/src/CAD_to_OpenMC/assemblymesher_cq.py
@@ -6,7 +6,7 @@ from .stl_utils import *
 from . import meshutils
 
 class MesherCQSTL:
-  def __init__(self, tolerance, angular_tolerance, default, refine, entities):
+  def __init__(self, tolerance, angular_tolerance, min_mesh_size, max_mesh_size, default, refine, entities):
     self.tolerance=tolerance
     self.angular_tolerance=angular_tolerance
     self.entities=entities
@@ -50,7 +50,7 @@ class MesherCQSTL:
     tris=buffer2triangles(buf,verts)
     edges=np.array(meshutils.find_edges(tris))
     meshutils.write_dotmesh(str(stlp.with_suffix('.mesh')),verts,tris,edges=edges,required_edges='all')
-    cp=sp.run(['mmgs_O3','-hausd','0.1','-optim','-in',stlp.with_suffix('.mesh'),'-out',stlp.with_suffix('.o.mesh')], capture_output=True)
+    cp=sp.run(['mmgs_O3','-hmin',f'{self.min_mesh_size}','-hmax',f'{self.max_mesh_size}','-optim','-in',stlp.with_suffix('.mesh'),'-out',stlp.with_suffix('.o.mesh')], capture_output=True)
     print(cp.stdout)
 
     import gmsh
@@ -135,7 +135,7 @@ class MesherCQSTLBuilder:
   def __init__(self):
     self._instance = None
 
-  def __call__(self, tolerance, angular_tolerance, default, refine, entities, **_ignored):
+  def __call__(self, tolerance, angular_tolerance, min_mesh_size, max_mesh_size, default, refine, entities, **_ignored):
     if not self._instance:
-      self._instance = MesherCQSTL(tolerance, angular_tolerance, default,refine, entities)
+      self._instance = MesherCQSTL(tolerance, angular_tolerance, min_mesh_size, max_mesh_size, default,refine, entities)
     return self._instance

--- a/src/CAD_to_OpenMC/meshutils.py
+++ b/src/CAD_to_OpenMC/meshutils.py
@@ -3,6 +3,7 @@
 """
 import struct
 import numpy
+import pathlib as pl
 from .stl_utils import *
 
 def write_dummy_dotsol(dest,nvertices:int=0):
@@ -44,7 +45,14 @@ def _write_vertex(fp,v,label=None):
   else:
     fp.write(f'{v[0]:24} {v[1]:24} {v[2]:24}  {label}\n')
 
-def write_dotmesh(dest, vertices, triangles,vertex_labels=None, triangle_labels=None):
+def _write_edge(fp,e,label=None):
+  if not label:
+    fp.write(f'{e[0]} {e[1]} 1\n')
+  else:
+    fp.write(f'{e[0]} {e[1]} {label}\n')
+
+
+def write_dotmesh(dest, vertices, triangles,vertex_labels=None, triangle_labels=None, edges=None, required_edges='all'):
   """ vertices and triangles can be lists of lists or 2d arrays """
   header=""" MeshVersionFormatted
  2
@@ -59,9 +67,52 @@ def write_dotmesh(dest, vertices, triangles,vertex_labels=None, triangle_labels=
     fp.write(' Vertices\n')
     fp.write(f' {nv}\n')
     for i in range(vertices.shape[0]):
-      _write_vertex(fp,vertices[i],label=vertex_labels[i])
+      try:
+        _write_vertex(fp,vertices[i],label=vertex_labels[i])
+      except:
+        _write_vertex(fp,vertices[i],label=None)
     fp.write(' Triangles\n')
     fp.write(f' {nt}\n')
     for i in range(nt):
-      _write_triangle(fp,triangles[i]+1,label=triangle_label[i])
+      try:
+        _write_triangle(fp,triangles[i]+1,label=triangle_labels[i])
+      except:
+        _write_triangle(fp,triangles[i]+1,label=None)
+    if (edges is not None):
+      ne=edges.shape[0]
+      fp.write(f'Edges\n{ne}\n')
+      for i in range(ne):
+        try:
+          _write_edge(fp,edges[i]+1,label=edge_labels[i])
+        except:
+          _write_edge(fp,edges[i]+1,label=None)
+      if (required_edges=='all'):
+        fp.write(f'RequiredEdges\n{ne}\n')
+        for i in range(ne):
+          fp.write(f'{i+1}\n')
     fp.write(' End\n')
+
+def find_edges(triangles):
+  """algorithm to find the edge lines in a set of triangles. I.e. the lines
+  which are only present in a single triangle"""
+  #loop over all triangles i = 0,...,N_t
+  #loop over the set of 3 possible edges e\in{ [v_0,v_1],[v_1,v_2],[v_3,v_4] } in T_i, where j\in{0,1,2}
+  #given an edge e_j, run through all triangles T_k, where i<k<=N_t
+  #if that edge is found move to next
+  #else append to list of edges
+  edges=[]
+  for i in range(triangles.shape[0]):
+    Ti=triangles[i]
+    ee_i=(sorted([Ti[0],Ti[1]]),sorted([Ti[1],Ti[2]]),sorted([Ti[2],Ti[0]]))
+    for j in range(3):
+      e_j=ee_i[j]
+      for k in range(triangles.shape[0]):
+        if (k==i):
+          continue
+        Tk=triangles[k]
+        ee_k=(sorted([Tk[0],Tk[1]]),sorted([Tk[1],Tk[2]]),sorted([Tk[2],Tk[0]]))
+        if(e_j in ee_k):
+          break
+      else:
+        edges.append(e_j)
+  return edges

--- a/src/CAD_to_OpenMC/meshutils.py
+++ b/src/CAD_to_OpenMC/meshutils.py
@@ -10,15 +10,14 @@ def write_dummy_dotsol(dest,nvertices:int=0):
 1
 
 Dimension 3
-SolAt Vertices
-
+SolAtVertices
 """
   with open(dest,"w") as fp:
     fp.write(header)
-    fp.write(nvertices)
-    fp.write('1 1')
+    fp.write(f'{nvertices}\n')
+    fp.write('1 1\n')
     fp.write('0\n'*nvertices)
-    fp.write('End')
+    fp.write('End\n')
 
 
 def _print_vertex(v,label=None):

--- a/src/CAD_to_OpenMC/meshutils.py
+++ b/src/CAD_to_OpenMC/meshutils.py
@@ -1,0 +1,68 @@
+"""
+  Set of utility functions that handle IO with the .mesh format
+"""
+import struct
+import numpy
+from .stl_utils import *
+
+def write_dummy_dotsol(dest,nvertices:int=0):
+  header="""MeshVersionFormatted
+1
+
+Dimension 3
+SolAt Vertices
+
+"""
+  with open(dest,"w") as fp:
+    fp.write(header)
+    fp.write(nvertices)
+    fp.write('1 1')
+    fp.write('0\n'*nvertices)
+    fp.write('End')
+
+
+def _print_vertex(v,label=None):
+  if not label:
+    print(f'{v[0]:24} {v[1]:24} {v[2]:24}  1')
+  else:
+    print(f'{v[0]:24} {v[1]:24} {v[2]:24}  {label}')
+
+def _print_triangle(tri,label=None):
+  if not label:
+    print(f' {tri[0]} {tri[1]} {tri[2]} 1')
+  else:
+    print(f' {tri[0]} {tri[1]} {tri[2]} {label}')
+
+def _write_triangle(fp,tri,label=None):
+  if not label:
+    fp.write(f' {tri[0]} {tri[1]} {tri[2]} 1\n')
+  else:
+    fp.write(f' {tri[0]} {tri[1]} {tri[2]} {label}\n')
+
+def _write_vertex(fp,v,label=None):
+  if not label:
+    fp.write(f'{v[0]:24} {v[1]:24} {v[2]:24}  1\n')
+  else:
+    fp.write(f'{v[0]:24} {v[1]:24} {v[2]:24}  {label}\n')
+
+def write_dotmesh(dest, vertices, triangles,vertex_labels=None, triangle_labels=None):
+  """ vertices and triangles can be lists of lists or 2d arrays """
+  header=""" MeshVersionFormatted
+ 2
+ Dimension
+ 3
+"""
+  nv=vertices.shape[0]
+  nt=triangles.shape[0]
+
+  with open(dest,"w") as fp:
+    fp.write(header)
+    fp.write(' Vertices\n')
+    fp.write(f' {nv}\n')
+    for i in range(vertices.shape[0]):
+      _write_vertex(fp,vertices[i])
+    fp.write(' Triangles\n')
+    fp.write(f' {nt}\n')
+    for i in range(nt):
+      _write_triangle(fp,triangles[i]+1)
+    fp.write(' End\n')

--- a/src/CAD_to_OpenMC/meshutils.py
+++ b/src/CAD_to_OpenMC/meshutils.py
@@ -59,9 +59,9 @@ def write_dotmesh(dest, vertices, triangles,vertex_labels=None, triangle_labels=
     fp.write(' Vertices\n')
     fp.write(f' {nv}\n')
     for i in range(vertices.shape[0]):
-      _write_vertex(fp,vertices[i])
+      _write_vertex(fp,vertices[i],label=vertex_labels[i])
     fp.write(' Triangles\n')
     fp.write(f' {nt}\n')
     for i in range(nt):
-      _write_triangle(fp,triangles[i]+1)
+      _write_triangle(fp,triangles[i]+1,label=triangle_label[i])
     fp.write(' End\n')

--- a/src/CAD_to_OpenMC/stl_utils.py
+++ b/src/CAD_to_OpenMC/stl_utils.py
@@ -35,7 +35,7 @@ def read_stl(src):
   magic_bytes=infp.read(5)
   if (magic_bytes[:5].decode('ascii')=='solid'):
     infp.close()
-    infp=open(s,'r')
+    infp=open(src,'r')
     buffer,n = read_stl_ascii(infp)
   else:
     buffer,n = read_stl_bin(infp)

--- a/src/CAD_to_OpenMC/stl_utils.py
+++ b/src/CAD_to_OpenMC/stl_utils.py
@@ -2,6 +2,7 @@
 a set of utility functions that deal with stl-files
 """
 import struct
+import numpy as np
 
 def merge_stl(dest,src, of='binary'):
   """
@@ -28,6 +29,17 @@ def merge_stl(dest,src, of='binary'):
       outputbuffer.extend(buffer)
       ntot+=n
   write_stl(dest, outputbuffer,of=of,header=outputbh)
+
+def read_stl(src):
+  infp=open(src,"rb")
+  magic_bytes=infp.read(5)
+  if (magic_bytes[:5].decode('ascii')=='solid'):
+    infp.close()
+    infp=open(s,'r')
+    buffer,n = read_stl_ascii(infp)
+  else:
+    buffer,n = read_stl_bin(infp)
+  return buffer,n
 
 def read_stl_ascii(infp):
   line=infp.readline()
@@ -77,11 +89,45 @@ def write_stl_bin(fname, faces, header=b'', color=None):
     outfp.write(b'\x00'*(80-len(header)))
     outfp.write(struct.pack('I',len(faces)))
     for facet in faces:
-      print(len(facet),*facet)
       outfp.write( struct.pack( '12f',*facet ) )
       #if necessary pad with the attribute byte count (15-bit color) - for now set to 0
       if (len(facet)==12):
         outfp.write(struct.pack('H',0))
+
+def buffer2vertices(buffer):
+  """take a raw buffer as returned by the functions above and extract only the vertices from it"""
+  # This amounts to extracting only the last 9 elements (i.e. disregard the normals),
+  # stacking them vertically to get a list of 3d-coordinates as rows.
+  # and return a list of unique rows
+  npbuf=np.array(buffer)
+  uqe=np.unique( np.vstack( (npbuf[:,3:6],npbuf[:,6:9],npbuf[:,9:12]) ),axis=0)
+  return uqe
+
+def find_vertex(v,vertices):
+  logic=(np.equal(vertices,v)).all(1)
+  idx=np.flatnonzero(logic)[0]
+  return idx
+
+def buffer2triangles(buffer,vertices=None):
+  if vertices is None:
+    vertices=buffer2vertices(buffer)
+  npbuf=np.array(buffer)[:,3:]
+  triangles=None
+  for i in range(npbuf.shape[0]):
+    v1=npbuf[i,0:3]
+    v2=npbuf[i,3:6]
+    v3=npbuf[i,6:9]
+    idx1=find_vertex(v1,vertices)
+    idx2=find_vertex(v2,vertices)
+    idx3=find_vertex(v3,vertices)
+    if triangles is None:
+      triangles=np.array([[idx1,idx2,idx3]])
+    else:
+      triangles=np.vstack((triangles,[idx1,idx2,idx3]))
+  return triangles
+
+
+
 
 if __name__=='__main__':
     import sys


### PR DESCRIPTION
This set of improvements gives the cq-backend a refinement option.

The backend calls the tool mmg https://www.mmgtools.org/ to refine the original surface meshes. - Each face in a volume is refined independently - but only once for identical surfaces, where the mesh is simply repeated.
Nodes on the faces' edges are preserved by identifying the lines in the initial mesh triangles, i.e. lines only present in a single triangle. This constitutes an edge. The edge information is provided to mmg which refines the mesh without moving the edges. Thus we may stitch surfaces without problems.

The tool calls mmg trhough a system call - this could be improved upon, such that the mesh would be refined in-memory, by using mmg as a library.

Limitations: The procedure creates an enormous amount of intermediary files. This is adressed by issue #3.
