### PR TITLE
Avoid accents and special characters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,9 @@ dependencies=[
         'numpy',
         'networkx',
         'trimesh',
+        'unidecode',
 ]
+
 
 [project.urls]
 "Homepage" = "https://github.com/openmsr/CAD_to_OpenMC"

--- a/src/CAD_to_OpenMC/assembly.py
+++ b/src/CAD_to_OpenMC/assembly.py
@@ -13,6 +13,7 @@ import os
 import math
 import sys
 
+from unidecode import unidecode
 from datetime import datetime
 
 from pymoab import core, types
@@ -316,7 +317,7 @@ class Assembly:
                         s = gmsh.model.getEntityName(3, vid)
                         part = s.split("/")[-1]
                         g = re.match(r"^([^\s_@]+)", part)
-                        tag = g[0]
+                        tag = unidecode(g[0])
                         if self.verbose > 1:
                             print(
                                 f"INFO: Tagging volume #{vid} label:{s} with material {tag}"


### PR DESCRIPTION
Add unidecode package to avoid special characters making into material tags. Instead map them onto the ascii-set