### PR TITLE
avoid special characters in tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies=[
         'numpy',
         'networkx',
         'trimesh',
+        'unidecode',
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 ]
 dependencies=[
         'gmsh',
+        'nympy<2.0a0',
         'pyparsing',
         'cadquery>=2',
         'cadquery-ocp>=7',

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ cadquery-ocp>=7.7.0
 numpy<2.0a0
 trimesh
 networkx
+unidecode
 Cython

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ gmsh
 pyparsing
 cadquery>=2.2.0
 cadquery-ocp>=7.7.0
-numpy
+numpy<2.0a<2.0a00
 trimesh
 networkx
 Cython

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ gmsh
 pyparsing
 cadquery>=2.2.0
 cadquery-ocp>=7.7.0
-numpy<2.0a<2.0a00
+numpy<2.0a0
 trimesh
 networkx
 Cython

--- a/src/CAD_to_OpenMC/assembly.py
+++ b/src/CAD_to_OpenMC/assembly.py
@@ -13,6 +13,7 @@ import os
 import math
 import sys
 
+from unidecode import unidecode
 from datetime import datetime
 
 from pymoab import core, types
@@ -315,7 +316,7 @@ class Assembly:
                         s = gmsh.model.getEntityName(3, vid)
                         part = s.split("/")[-1]
                         g = re.match(r"^([^\s_@]+)", part)
-                        tag = g[0]
+                        tag = unidecode(g[0])
                         if self.verbose > 1:
                             print(
                                 f"INFO: Tagging volume #{vid} label:{s} with material {tag}"


### PR DESCRIPTION
special characters in tags can cause crashes - this PR adds unidecode as a dep and asuse it to map specials to standard ascii