### PR TITLE
add h4py as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies=[
         'numpy',
         'networkx',
         'unidecode',
+        'h5py',
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ cadquery-ocp>=7.7.0
 numpy
 networkx
 unidecode
+h5py
 Cython


### PR DESCRIPTION
A new test explicitly depends on h5py - add that as a dependency